### PR TITLE
Adjust codeclimate settings and Fix Jacoco 

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,23 @@
+checks:
+  complex-logic:
+    config:
+      threshold: 50
+  file-lines:
+    config:
+      threshold: 500
+  method-complexity:
+    config:
+      threshold: 50
+  method-lines:
+    config:
+      threshold: 50
+  similar-code:
+    config:
+      threshold: 8
+  identical-code:
+    config:
+      threshold: 8
+
 exclude_patterns:
   - "**/test/"
   - "**/androidTest/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -13,10 +13,10 @@ checks:
       threshold: 50
   similar-code:
     config:
-      threshold: 8
+      threshold: 120
   identical-code:
     config:
-      threshold: 8
+      threshold: 120
 
 exclude_patterns:
   - "**/test/"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,7 +86,8 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'crea
     sourceDirectories.setFrom(files([mainSrc]))
     classDirectories.setFrom(files([debugTree]))
     executionData.setFrom(fileTree(dir: project.buildDir, includes: [
-            'jacoco/testDebugUnitTest.exec', 'outputs/code_coverage/debugAndroidTest/connected/*coverage.ec'
+            'outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec',
+            'outputs/code_coverage/debugAndroidTest/connected/*/coverage.ec'
     ]))
 }
 


### PR DESCRIPTION
Adjusts some advanced settings on codeclimate to make it less aggressive and adjust Jacoco settings to account for unit tests. The changes have been made as advised by the TAs in both cases.