### PR TITLE
108 fix firebase double autoconversion bug

### DIFF
--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/FirebaseTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/FirebaseTest.kt
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class FirebaseTest {
-    // Key used for testing purposes
+ /*   // Key used for testing purposes
     private val testingKey = "TESTING_KEY"
     private val testingListenerKey = "TESTING_LISTENER_KEY"
     // Dummy class for complex types
@@ -46,5 +46,5 @@ class FirebaseTest {
             db.clearListeners(testingListenerKey)
             assertEquals(old + 1.0, db.getDouble(testingListenerKey).get())
         }
-    }
+    }*/
 }

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/FirebaseTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/FirebaseTest.kt
@@ -8,7 +8,7 @@ import junit.framework.TestCase.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 
-/*@RunWith(AndroidJUnit4::class)
+@RunWith(AndroidJUnit4::class)
 class FirebaseTest {
     // Key used for testing purposes
     private val testingKey = "TESTING_KEY"
@@ -26,12 +26,12 @@ class FirebaseTest {
             db.setInt(testingKey + 1, 1)
             db.setString(testingKey + 2, "1")
             db.setBoolean(testingKey + 3, false)
-            db.setDouble(testingKey + 4, 1.1)
+            db.setDouble(testingKey + 4, 1.0)
             db.setObject(testingKey + 5, Foo::class.java, foo)
             assertEquals(1, db.getInt(testingKey + 1).get())
             assertEquals("1", db.getString(testingKey + 2).get())
             assertEquals(false, db.getBoolean(testingKey + 3).get())
-            assertEquals(1.1, db.getDouble(testingKey + 4).get())
+            assertEquals(1.0, db.getDouble(testingKey + 4).get())
             assertEquals(foo, db.getObject(testingKey + 5, Foo::class.java).get())
         }
     }
@@ -40,11 +40,11 @@ class FirebaseTest {
     fun listenerListensAndCloses() {
         // Start a listener, trigger it and close it directly
         val db = databaseOf(EMERGENCIES)
-        val old = db.getInt(testingListenerKey).get()
+        val old = db.getDouble(testingListenerKey).get()
         db.addListener(testingListenerKey, Int::class.java) {
-            db.setInt(testingListenerKey, it + 1)
+            db.setDouble(testingListenerKey, it + 1.0)
             db.clearListeners(testingListenerKey)
-            assertEquals(old + 1, db.getInt(testingListenerKey).get())
+            assertEquals(old + 1.0, db.getDouble(testingListenerKey).get())
         }
     }
-}*/
+}

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/FirebaseTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/FirebaseTest.kt
@@ -8,9 +8,9 @@ import junit.framework.TestCase.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
+/*@RunWith(AndroidJUnit4::class)
 class FirebaseTest {
- /*   // Key used for testing purposes
+   // Key used for testing purposes
     private val testingKey = "TESTING_KEY"
     private val testingListenerKey = "TESTING_LISTENER_KEY"
     // Dummy class for complex types
@@ -46,5 +46,5 @@ class FirebaseTest {
             db.clearListeners(testingListenerKey)
             assertEquals(old + 1.0, db.getDouble(testingListenerKey).get())
         }
-    }*/
-}
+    }
+}*/

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
             android:name=".CprRateActivity"
             android:exported="false" />
         <activity
-            android:name=".MainPageActivity"
+            android:name=".signin.SignInActivity"
             android:exported="true" />
         <activity
             android:name=".presentation.PresIrrelevantActivity"
@@ -71,7 +71,7 @@
             android:name=".presentation.PresArrivalActivity"
             android:exported="false" />
         <activity
-            android:name=".signin.SignInActivity"
+            android:name=".MainPageActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
             android:name=".CprRateActivity"
             android:exported="false" />
         <activity
-            android:name=".signin.SignInActivity"
+            android:name=".MainPageActivity"
             android:exported="true" />
         <activity
             android:name=".presentation.PresIrrelevantActivity"
@@ -71,7 +71,7 @@
             android:name=".presentation.PresArrivalActivity"
             android:exported="false" />
         <activity
-            android:name=".MainPageActivity"
+            android:name=".signin.SignInActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/MainPageActivity.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/MainPageActivity.kt
@@ -149,17 +149,15 @@ class MainPageActivity : AppCompatActivity(), OnRequestPermissionsResultCallback
             true
         }
         // Demo code
-        // addAlertNotification()
+        //addAlertNotification()
     }
 
     // Demo code
     private fun addAlertNotification() {
-        val db = databaseOf(Databases.NEW_EMERGENCIES)
-        db.addListener(getString(R.string.ventolin_db_key), String::class.java) {
-            if(it.equals(getString(R.string.help))){
-                db.setString(getString(R.string.ventolin_db_key),getString(R.string.nothing))
-                sendNotification(getString(R.string.emergency),getString(R.string.need_help))
-            }
+        val db = databaseOf(Databases.EMERGENCIES)
+        db.addListener("Test", Double::class.java) {
+                sendNotification(getString(R.string.emergency),it.toString())
+
         }
     }
 

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/MainPageActivity.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/MainPageActivity.kt
@@ -148,18 +148,10 @@ class MainPageActivity : AppCompatActivity(), OnRequestPermissionsResultCallback
             }
             true
         }
-        // Demo code
-        //addAlertNotification()
+
     }
 
-    // Demo code
-    private fun addAlertNotification() {
-        val db = databaseOf(Databases.EMERGENCIES)
-        db.addListener("Test", Double::class.java) {
-                sendNotification(getString(R.string.emergency),it.toString())
 
-        }
-    }
 
     private fun sendNotification(textTitle: String,textContent:String){
         AlertDialog.Builder(this).setTitle(textTitle).setMessage(textContent).setIcon(R.drawable.notification_icon).show()

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/database/FireDatabase.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/database/FireDatabase.kt
@@ -78,10 +78,11 @@ class FireDatabase(path: String) : Database {
      * @return Future of double
      */
     override fun getDouble(key: String): CompletableFuture<Double> {
-        //This Fix is due to an misconception in firebase:
-        //Storing 3.0 in fire base will automatically transform it in an long integer.
-        //This result when getting it as an type error since long cannot be direct cast as double
-        //This is fix getting the field as the super class number and then casting it with its function
+        // This Fix is due to a misconception in firebase:
+        // Storing 3.0 in firebase will automatically transform it into a long integer.
+        // This causes a type error when getting it since long cannot be directly cast to double.
+        // This is fixed by getting the field as the superclass number and then casting it with its function.
+
         val number :CompletableFuture<Number> = get(key)
         return number.thenApply { n -> n.toDouble() }
     }

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/database/FireDatabase.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/database/FireDatabase.kt
@@ -78,7 +78,12 @@ class FireDatabase(path: String) : Database {
      * @return Future of double
      */
     override fun getDouble(key: String): CompletableFuture<Double> {
-        return get(key)
+        //This Fix is due to an misconception in firebase:
+        //Storing 3.0 in fire base will automatically transform it in an long integer.
+        //This result when getting it as an type error since long cannot be direct cast as double
+        //This is fix getting the field as the super class number and then casting it with its function
+        val number :CompletableFuture<Number> = get(key)
+        return number.thenApply { n -> n.toDouble() }
     }
 
     /**


### PR DESCRIPTION
Fix Firebase bug due to Firebase inconsistency.

While using Firebase with double could lead to error. Storing round number like 3.0 as double in db, firebase optimize it as storing as 3 a long. But when retrieving this data it cause a type cast error because the incapacity to cast long to double.

I tried many fix and I ended up with these, using super class Number of kotlin