### PR TITLE
Implement mocking database and related tests

### DIFF
--- a/app/src/main/java/com/github/h3lp3rs/h3lp/database/Database.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/database/Database.kt
@@ -88,6 +88,7 @@ interface Database {
 
     /**
      * Applies an arbitrary action when the value associated to the key changes
+     * WARNING: This function automatically triggers at first when linked with a valid key
      * @param key The key in the database
      * @param action The action taken at change
      */

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/database/Databases.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/database/Databases.kt
@@ -5,8 +5,12 @@ package com.github.h3lp3rs.h3lp.database
  */
 enum class Databases {
     PREFERENCES, EMERGENCIES, NEW_EMERGENCIES;
-    val db: Database = FireDatabase(name)
+    var db: Database = FireDatabase(name) // Var to enable test-time mocking
     companion object {
+        /**
+         * Instantiates the database of the corresponding type
+         * @param choice The chosen database
+         */
         fun databaseOf(choice: Databases): Database {
             return choice.db
         }

--- a/app/src/test/java/com/github/h3lp3rs/h3lp/MockDatabaseTest.kt
+++ b/app/src/test/java/com/github/h3lp3rs/h3lp/MockDatabaseTest.kt
@@ -1,0 +1,98 @@
+package com.github.h3lp3rs.h3lp
+
+import com.github.h3lp3rs.h3lp.database.Database
+import com.github.h3lp3rs.h3lp.database.MockDatabase
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import kotlin.random.Random
+
+class MockDatabaseTest {
+
+    // Dummy class for complex types
+    private data class Foo(val a1: Double, val a2: String)
+    // Useful variables
+    private lateinit var db: Database
+    private val TEST_KEY = "KEY"
+    private val TEST_SEED = Random(0)
+    private val BYTES_PER_CHAR = 2
+    private val DELTA = 1e-10
+
+    @Before
+    fun setup() {
+        db = MockDatabase()
+    }
+
+    @Test
+    fun setAndGetWorksProperly() {
+        val int = TEST_SEED.nextInt()
+        val string = TEST_SEED.nextBytes(5 * BYTES_PER_CHAR).toString()
+        val bool = TEST_SEED.nextBoolean()
+        val double = TEST_SEED.nextDouble()
+        val obj = Foo(double, string)
+
+        db.setInt(TEST_KEY, int)
+        assertEquals(int, db.getInt(TEST_KEY).get())
+
+        db.setString(TEST_KEY, string)
+        assertEquals(string, db.getString(TEST_KEY).get())
+
+        db.setBoolean(TEST_KEY, bool)
+        assertEquals(bool, db.getBoolean(TEST_KEY).get())
+
+        db.setDouble(TEST_KEY, double)
+        assertEquals(double, db.getDouble(TEST_KEY).get(), DELTA)
+
+        db.setObject(TEST_KEY, Foo::class.java, obj)
+        assertEquals(obj, db.getObject(TEST_KEY, Foo::class.java).get())
+    }
+
+    @Test
+    fun deleteWorksProperly() {
+        val int = TEST_SEED.nextInt()
+        db.setInt(TEST_KEY, int)
+        assertEquals(int, db.getInt(TEST_KEY).get())
+        db.delete(TEST_KEY)
+        assertTrue(db.getInt(TEST_KEY).isCompletedExceptionally)
+    }
+
+    @Test
+    fun addListenerIsTriggeredAtFirst() {
+        var flag = false
+        val int = TEST_SEED.nextInt()
+        db.setInt(TEST_KEY, int)
+        db.addListener(TEST_KEY, Int::class.java) {
+            flag = true
+        }
+        assertTrue(flag)
+    }
+
+    @Test
+    fun listenerIsTriggeredAtChange() {
+        var flag = false
+        val old = TEST_SEED.nextInt()
+        db.setInt(TEST_KEY, old)
+        db.addListener(TEST_KEY, Int::class.java) {
+            if (it != old) {
+                flag = true
+            }
+        }
+        db.setInt(TEST_KEY, old + 1)
+        assertTrue(flag)
+    }
+
+    @Test
+    fun listenerAreProperlyDeleted() {
+        var flag = false
+        val old = TEST_SEED.nextInt()
+        db.setInt(TEST_KEY, old)
+        db.addListener(TEST_KEY, Int::class.java) {
+            if (it != old) {
+                flag = true
+            }
+        }
+        db.clearListeners(TEST_KEY)
+        db.setInt(TEST_KEY, old + 1)
+        assertTrue(!flag)
+    }
+}


### PR DESCRIPTION
According to #106, this PR contains the addition of a mocked database that can be used for testing purposes.

This implementation offers the advantage of being able to test usual production code without having to modify it.

Indeed, when writing tests, the developer just has to replace the corresponding databases in the Databases enumeration with MockDatabases they created for this purpose.