### PR TITLE
131/135 various bugfixes

### DIFF
--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/CprRateActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/CprRateActivityTest.kt
@@ -1,7 +1,9 @@
 package com.github.h3lp3rs.h3lp
 
 import android.content.Context
+import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.core.app.ApplicationProvider.*
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -16,7 +18,7 @@ import androidx.test.espresso.ViewInteraction
 
 @RunWith(AndroidJUnit4::class)
 class CprRateActivityTest {
-    private val targetContext: Context = ApplicationProvider.getApplicationContext()
+    private val targetContext: Context = getApplicationContext()
     private val startText =  targetContext.resources.getString(R.string.cpr_rate_button_start)
     private val stopText =  targetContext.resources.getString(R.string.cpr_rate_button_stop)
     private val rateButton: ViewInteraction = onView(withId(R.id.startRateButton))
@@ -41,6 +43,19 @@ class CprRateActivityTest {
     @Test
     fun buttonTextCycles() {
         rateButton.perform(click()).perform(click())
+        rateButton.check(matches(withText(startText)))
+    }
+
+    /**
+     * Checking that the cpr resets when removed from screen
+     */
+    @Test
+    fun onPauseResetsCpr() {
+        buttonHasRightTextValueAfterClick()
+        // Pause and resume activity
+        testRule.scenario.moveToState(Lifecycle.State.STARTED)
+        testRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        rateButton.check(matches(isDisplayed()))
         rateButton.check(matches(withText(startText)))
     }
 }

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/CprRateActivity.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/CprRateActivity.kt
@@ -9,18 +9,23 @@ import android.widget.ImageView
 import android.media.MediaPlayer
 
 class CprRateActivity : AppCompatActivity() {
+
     private var animationIsPlaying = false
+    private lateinit var startButton: Button
+    private lateinit var heartIcon: ImageView
+    private lateinit var heartBeatAnimation: Animation
+    private lateinit var beepSound: MediaPlayer
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_cpr_rate)
 
-        val startButton = findViewById<Button>(R.id.startRateButton)
-        val heartIcon = findViewById<ImageView>(R.id.heartIcon)
-        val heartBeatAnimation = AnimationUtils.loadAnimation(this, R.anim.heartbeat_animation)
+        // Initialization of CPR activity
+        startButton = findViewById(R.id.startRateButton)
+        heartIcon = findViewById(R.id.heartIcon)
+        heartBeatAnimation = AnimationUtils.loadAnimation(this, R.anim.heartbeat_animation)
 
-
-        val beepSound = MediaPlayer.create(this, R.raw.beep)
+        beepSound = MediaPlayer.create(this, R.raw.beep)
         beepSound.isLooping = true
 
         /**
@@ -45,18 +50,36 @@ class CprRateActivity : AppCompatActivity() {
 
         startButton.setOnClickListener {
             if (animationIsPlaying) {
-                //heartIcon.clearAnimation()
-                startButton.text = getString(R.string.cpr_rate_button_start)
-                beepSound.pause()
-                beepSound.seekTo(0)
-                animationIsPlaying = false
+                stop()
             } else {
-                //heartIcon.startAnimation(heartBeatAnimation)
-                startButton.text = getString(R.string.cpr_rate_button_stop)
-                beepSound.start()
-                animationIsPlaying = true
+                start()
             }
 
         }
+    }
+
+    /**
+     * Stop all the animations when the user does no longer see the activity
+     */
+    override fun onStop() {
+        stop()
+        super.onStop()
+    }
+
+    // Stops the CPR rate
+    private fun stop() {
+        //heartIcon.clearAnimation()
+        startButton.text = getString(R.string.cpr_rate_button_start)
+        beepSound.pause()
+        beepSound.seekTo(0)
+        animationIsPlaying = false
+    }
+
+    // Starts the CPR rate
+    private fun start() {
+        //heartIcon.startAnimation(heartBeatAnimation)
+        startButton.text = getString(R.string.cpr_rate_button_stop)
+        beepSound.start()
+        animationIsPlaying = true
     }
 }

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/CprRateActivity.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/CprRateActivity.kt
@@ -54,16 +54,16 @@ class CprRateActivity : AppCompatActivity() {
             } else {
                 start()
             }
-
         }
     }
 
     /**
-     * Stop all the animations when the user does no longer see the activity
+     * Stop all the animations when the cpr is no longer
+     * in the foreground.
      */
-    override fun onStop() {
+    override fun onPause() {
         stop()
-        super.onStop()
+        super.onPause()
     }
 
     // Stops the CPR rate

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/database/Database.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/database/Database.kt
@@ -107,7 +107,7 @@ interface Database {
     fun delete(key: String)
 
     /**
-     * Atomically increments an integer value of the database by one
+     * Atomically increments an integer value of the database
      * @param key The key in the database
      * @param number The number to increment by
      */

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/database/Database.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/database/Database.kt
@@ -102,7 +102,13 @@ interface Database {
 
     /**
      * Deletes an entry of a given key from the database
-     * @param key They key in the database
+     * @param key The key in the database
      */
     fun delete(key: String)
+
+    /**
+     * Atomically increments an integer value of the database
+     * @param key The key in the database
+     */
+    fun increment(key: String)
 }

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/database/Database.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/database/Database.kt
@@ -107,8 +107,9 @@ interface Database {
     fun delete(key: String)
 
     /**
-     * Atomically increments an integer value of the database
+     * Atomically increments an integer value of the database by one
      * @param key The key in the database
+     * @param number The number to increment by
      */
-    fun increment(key: String)
+    fun incrementBy(key: String, number: Int)
 }

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/database/FireDatabase.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/database/FireDatabase.kt
@@ -166,7 +166,7 @@ internal class FireDatabase(path: String) : Database {
     }
 
     /**
-     * Atomically increments an integer value of the database by one
+     * Atomically increments an integer value of the database
      * @param key The key in the database
      * @param number The number to increment by
      */

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/database/FireDatabase.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/database/FireDatabase.kt
@@ -166,10 +166,11 @@ internal class FireDatabase(path: String) : Database {
     }
 
     /**
-     * Atomically increments an integer value of the database
+     * Atomically increments an integer value of the database by one
      * @param key The key in the database
+     * @param number The number to increment by
      */
-    override fun increment(key: String) {
-        db.child(key).setValue(ServerValue.increment(1))
+    override fun incrementBy(key: String, number: Int) {
+        db.child(key).setValue(ServerValue.increment(number.toLong()))
     }
 }

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/database/FireDatabase.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/database/FireDatabase.kt
@@ -1,9 +1,6 @@
 package com.github.h3lp3rs.h3lp.database
 
-import com.google.firebase.database.DataSnapshot
-import com.google.firebase.database.DatabaseError
-import com.google.firebase.database.DatabaseReference
-import com.google.firebase.database.ValueEventListener
+import com.google.firebase.database.*
 import com.google.firebase.database.ktx.*
 import com.google.firebase.ktx.Firebase
 import com.google.gson.Gson
@@ -166,5 +163,13 @@ internal class FireDatabase(path: String) : Database {
     override fun delete(key: String) {
         clearListeners(key)
         db.child(key).removeValue()
+    }
+
+    /**
+     * Atomically increments an integer value of the database
+     * @param key The key in the database
+     */
+    override fun increment(key: String) {
+        db.child(key).setValue(ServerValue.increment(1))
     }
 }

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/database/MockDatabase.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/database/MockDatabase.kt
@@ -159,14 +159,15 @@ class MockDatabase : Database {
     }
 
     /**
-     * Atomically increments an integer value of the database
+     * Atomically increments an integer value of the database by one
      * @param key The key in the database
+     * @param number The number to increment by
      */
-    override fun increment(key: String) {
+    override fun incrementBy(key: String, number: Int) {
         checkHasKey(db, key)
         synchronized(this) {
             val old = db[key] as Int
-            db.put(key, old + 1)
+            db.put(key, old + number)
         }
     }
 }

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/database/MockDatabase.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/database/MockDatabase.kt
@@ -159,7 +159,7 @@ class MockDatabase : Database {
     }
 
     /**
-     * Atomically increments an integer value of the database by one
+     * Atomically increments an integer value of the database
      * @param key The key in the database
      * @param number The number to increment by
      */

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/database/MockDatabase.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/database/MockDatabase.kt
@@ -157,4 +157,16 @@ class MockDatabase : Database {
         db.remove(key)
         listeners.remove(key)
     }
+
+    /**
+     * Atomically increments an integer value of the database
+     * @param key The key in the database
+     */
+    override fun increment(key: String) {
+        checkHasKey(db, key)
+        synchronized(this) {
+            val old = db[key] as Int
+            db.put(key, old + 1)
+        }
+    }
 }

--- a/app/src/test/java/com/github/h3lp3rs/h3lp/MockDatabaseTest.kt
+++ b/app/src/test/java/com/github/h3lp3rs/h3lp/MockDatabaseTest.kt
@@ -5,6 +5,7 @@ import com.github.h3lp3rs.h3lp.database.MockDatabase
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import kotlin.concurrent.thread
 import kotlin.random.Random
 
 class MockDatabaseTest {
@@ -94,5 +95,16 @@ class MockDatabaseTest {
         db.clearListeners(TEST_KEY)
         db.setInt(TEST_KEY, old + 1)
         assertTrue(!flag)
+    }
+
+    @Test
+    fun incrementIsAtomic() {
+        val old = TEST_SEED.nextInt()
+        db.setInt(TEST_KEY, old)
+        val t1 = thread { db.increment(TEST_KEY) }
+        val t2 = thread { db.increment(TEST_KEY) }
+        db.increment(TEST_KEY)
+        t1.join(); t2.join()
+        assertEquals(old + 3, db.getInt(TEST_KEY).get())
     }
 }

--- a/app/src/test/java/com/github/h3lp3rs/h3lp/MockDatabaseTest.kt
+++ b/app/src/test/java/com/github/h3lp3rs/h3lp/MockDatabaseTest.kt
@@ -101,9 +101,9 @@ class MockDatabaseTest {
     fun incrementIsAtomic() {
         val old = TEST_SEED.nextInt()
         db.setInt(TEST_KEY, old)
-        val t1 = thread { db.increment(TEST_KEY) }
-        val t2 = thread { db.increment(TEST_KEY) }
-        db.increment(TEST_KEY)
+        val t1 = thread { db.incrementBy(TEST_KEY, 1) }
+        val t2 = thread { db.incrementBy(TEST_KEY, 1) }
+        db.incrementBy(TEST_KEY, 1)
         t1.join(); t2.join()
         assertEquals(old + 3, db.getInt(TEST_KEY).get())
     }


### PR DESCRIPTION
This PR handles both #131 and #135:

- The PCR bug #131 has been fixed using the onPause function of an Android activity. Animations and sound objects had to be put as class attributes in order to access them later (which also makes more conceptual sense). Fortunately, this fix did not break any test.
- The atomic increment fix/enhancement #135 has been added on both Firebase and Mockbase. Mockbase tests have been added to increase coverage. The Firebase function has been tested locally and is fully functional. Although a one liner, it was not easy to find (online documentation is often confusing with Firestore Vs Firebase).

Both issues have been merged since they are small bugfixes. However, you can seperate both using the commit history.