### PR TITLE
203 - Refactor code duplication and make map utilization uniform

### DIFF
--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/AwaitHelpActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/AwaitHelpActivityTest.kt
@@ -34,17 +34,9 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.`when` as When
-import org.mockito.Mockito.mock
-import org.mockito.kotlin.anyOrNull
-import org.mockito.Mockito.*
-import java.util.concurrent.CompletableFuture.completedFuture
 import kotlin.collections.ArrayList
 
 class AwaitHelpActivityTest : H3lpAppTest() {
-    private val locationManagerMock: LocationManagerInterface =
-        mock(LocationManagerInterface::class.java)
-    private val locationMock: Location = mock(Location::class.java)
 
     @get:Rule
     val testRule = ActivityScenarioRule(
@@ -56,12 +48,8 @@ class AwaitHelpActivityTest : H3lpAppTest() {
 
     @Before
     fun setup() {
-        GeneralLocationManager.set(locationManagerMock)
+        mockEmptyLocation()
         init()
-
-        When(locationManagerMock.getCurrentLocation(anyOrNull())).thenReturn(
-            completedFuture(locationMock)
-        )
 
         globalContext = getApplicationContext()
         userUid = USER_TEST_ID

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/AwaitHelpActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/AwaitHelpActivityTest.kt
@@ -2,7 +2,6 @@ package com.github.h3lp3rs.h3lp
 
 import android.Manifest
 import android.content.Intent
-import android.location.Location
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
@@ -24,8 +23,6 @@ import com.github.h3lp3rs.h3lp.database.MockDatabase
 import com.github.h3lp3rs.h3lp.dataclasses.*
 import com.github.h3lp3rs.h3lp.firstaid.AedActivity
 import com.github.h3lp3rs.h3lp.firstaid.AllergyActivity
-import com.github.h3lp3rs.h3lp.locationmanager.GeneralLocationManager
-import com.github.h3lp3rs.h3lp.locationmanager.LocationManagerInterface
 import com.github.h3lp3rs.h3lp.signin.SignInActivity.Companion.globalContext
 import com.github.h3lp3rs.h3lp.signin.SignInActivity.Companion.userUid
 import org.hamcrest.Matcher

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/FirstAidActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/FirstAidActivityTest.kt
@@ -25,7 +25,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class FirstAidActivityTest {
+class FirstAidActivityTest : H3lpAppTest() {
 
     @get:Rule
     val testRule = ActivityScenarioRule(
@@ -34,10 +34,7 @@ class FirstAidActivityTest {
 
     @Before
     fun setup() {
-        init()
-        val intent = Intent()
-        val intentResult = ActivityResult(Activity.RESULT_OK, intent)
-        intending(anyIntent()).respondWith(intentResult)
+        initIntentAndCheckResponse()
     }
 
     @After

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/GuideTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/GuideTest.kt
@@ -19,7 +19,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class GuideTest {
+class GuideTest : H3lpAppTest() {
 
     private fun launch(): ActivityScenario<MainPageActivity> {
         return launch(Intent(getApplicationContext(), MainPageActivity::class.java))

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/H3lpAppTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/H3lpAppTest.kt
@@ -1,11 +1,12 @@
 package com.github.h3lp3rs.h3lp
 
 import android.app.Activity
-import android.app.Instrumentation
+import android.app.Instrumentation.ActivityResult
 import android.content.Intent
 import android.location.Location
 import android.net.Uri
 import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.*
 import androidx.test.espresso.intent.matcher.IntentMatchers
 import com.github.h3lp3rs.h3lp.dataclasses.*
 import com.github.h3lp3rs.h3lp.dataclasses.BloodType.ABn
@@ -17,6 +18,7 @@ import com.github.h3lp3rs.h3lp.locationmanager.GeneralLocationManager
 import com.github.h3lp3rs.h3lp.locationmanager.LocationManagerInterface
 import com.github.h3lp3rs.h3lp.signin.SignInActivity
 import com.github.h3lp3rs.h3lp.storage.Storages
+import com.github.h3lp3rs.h3lp.storage.Storages.Companion.storageOf
 import com.github.h3lp3rs.h3lp.storage.Storages.MEDICAL_INFO
 import org.apache.commons.lang3.RandomUtils.nextBoolean
 import org.mockito.Mockito.`when` as When
@@ -41,10 +43,10 @@ open class H3lpAppTest {
      * intent capture
      */
     fun initIntentAndCheckResponse() {
-        Intents.init()
+        init()
         val intent = Intent()
-        val intentResult = Instrumentation.ActivityResult(Activity.RESULT_OK, intent)
-        Intents.intending(IntentMatchers.anyIntent()).respondWith(intentResult)
+        val intentResult = ActivityResult(Activity.RESULT_OK, intent)
+        intending(IntentMatchers.anyIntent()).respondWith(intentResult)
     }
 
     /**
@@ -52,7 +54,7 @@ open class H3lpAppTest {
      * storage
      */
     fun loadValidMedicalDataToStorage() {
-        Storages.storageOf(MEDICAL_INFO)
+        storageOf(MEDICAL_INFO)
             .setObject(
                 SignInActivity.globalContext.getString(R.string.medical_info_key),
                 MedicalInformation::class.java, VALID_MEDICAL_INFO)

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/H3lpAppTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/H3lpAppTest.kt
@@ -115,6 +115,10 @@ open class H3lpAppTest {
         const val WAIT_UI = 500L
         const val TEST_TIMEOUT = 3000L
 
+        const val SWISS_LAT = 46.514
+        const val SWISS_LONG = 6.604
+        const val SWISS_EMERGENCY_NUMBER = "144"
+
         const val EPIPEN = "Epipen"
 
         val EPIPEN_SKILL = HelperSkills(

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/H3lpAppTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/H3lpAppTest.kt
@@ -1,0 +1,86 @@
+package com.github.h3lp3rs.h3lp
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
+import android.net.Uri
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
+import com.github.h3lp3rs.h3lp.dataclasses.*
+import com.github.h3lp3rs.h3lp.dataclasses.BloodType.ABn
+import com.github.h3lp3rs.h3lp.dataclasses.Gender.Female
+import com.github.h3lp3rs.h3lp.dataclasses.Gender.Male
+import com.github.h3lp3rs.h3lp.dataclasses.MedicalInformation.Companion.MAX_HEIGHT
+import com.github.h3lp3rs.h3lp.dataclasses.MedicalInformation.Companion.MAX_WEIGHT
+import com.github.h3lp3rs.h3lp.signin.SignInActivity
+import com.github.h3lp3rs.h3lp.storage.Storages
+import com.github.h3lp3rs.h3lp.storage.Storages.MEDICAL_INFO
+import org.apache.commons.lang3.RandomUtils
+import org.apache.commons.lang3.RandomUtils.nextBoolean
+import java.util.*
+
+/**
+ * Super class for tests in this app containing useful constants and functions
+ * that are common to many tests
+ */
+open class H3lpAppTest {
+
+    /**
+     * Auxiliary function to perform the repetitive step of starting espresso's
+     * intent capture
+     */
+    fun initIntentAndCheckResponse() {
+        Intents.init()
+        val intent = Intent()
+        val intentResult = Instrumentation.ActivityResult(Activity.RESULT_OK, intent)
+        Intents.intending(IntentMatchers.anyIntent()).respondWith(intentResult)
+    }
+
+    /**
+     * Auxiliary function to load a valid medical information to the corresponding
+     * storage
+     */
+    fun loadValidMedicalDataToStorage(){
+        Storages.storageOf(MEDICAL_INFO)
+            .setObject(
+                SignInActivity.globalContext.getString(R.string.medical_info_key),
+                MedicalInformation::class.java, VALID_MEDICAL_INFO)
+    }
+
+    companion object {
+        val TEST_URI: Uri = Uri.EMPTY
+
+        const val TEST_STRING = ""
+        const val IMAGE_INTENT = "image/*"
+
+        val VALID_FORMAT_NUMBERS = arrayOf("0216933000", "216933000", "+41216933000")
+        const val VALID_CONTACT_NUMBER = "+41216933000"
+        const val USER_TEST_ID = "SECRET_AGENT_007"
+        const val TEST_EMERGENCY_ID = "1"
+
+        const val WAIT_UI = 500L
+        const val TEST_TIMEOUT = 3000L
+
+        const val EPIPEN = "Epipen"
+
+        val EPIPEN_SKILL = HelperSkills(
+            true, false,false, false,false, false
+        )
+
+        val EPIPEN_EMERGENCY_INFO = EmergencyInformation(
+            TEST_EMERGENCY_ID, 1.0,1.0, EPIPEN_SKILL,
+            ArrayList(listOf(EPIPEN)), Date(), null, ArrayList())
+
+        val VALID_MEDICAL_INFO = MedicalInformation(
+            MAX_HEIGHT -1,
+            MAX_WEIGHT -1,
+            if(nextBoolean()) Male else Female, // no gender is more valid than the other
+            Calendar.getInstance().get(Calendar.YEAR),
+            "",
+            "",
+            "",
+            ABn,
+            "",
+            VALID_CONTACT_NUMBER)
+    }
+}

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/H3lpAppTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/H3lpAppTest.kt
@@ -19,8 +19,7 @@ import com.github.h3lp3rs.h3lp.signin.SignInActivity
 import com.github.h3lp3rs.h3lp.storage.Storages
 import com.github.h3lp3rs.h3lp.storage.Storages.MEDICAL_INFO
 import org.apache.commons.lang3.RandomUtils.nextBoolean
-import org.mockito.Mockito
-import org.mockito.Mockito.`when`
+import org.mockito.Mockito.`when` as When
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.anyOrNull
 import java.lang.RuntimeException
@@ -63,7 +62,7 @@ open class H3lpAppTest {
      * Mocking the user's location to a null values
      */
     fun mockEmptyLocation(){
-        `when`(locationManagerMock.getCurrentLocation(anyOrNull())).thenReturn(
+        When(locationManagerMock.getCurrentLocation(anyOrNull())).thenReturn(
             CompletableFuture.completedFuture(
                 locationMock
             )
@@ -75,11 +74,11 @@ open class H3lpAppTest {
      * Mocking the user's location to a predefined set of coordinates
      */
     fun mockLocationToCoordinates(longitude: Double, latitude: Double) {
-        `when`(locationManagerMock.getCurrentLocation(anyOrNull())).thenReturn(
+        When(locationManagerMock.getCurrentLocation(anyOrNull())).thenReturn(
             CompletableFuture.completedFuture(locationMock)
         )
-        `when`(locationMock.longitude).thenReturn(longitude)
-        `when`(locationMock.latitude).thenReturn(latitude)
+        When(locationMock.longitude).thenReturn(longitude)
+        When(locationMock.latitude).thenReturn(latitude)
         GeneralLocationManager.set(locationManagerMock)
     }
 
@@ -92,7 +91,7 @@ open class H3lpAppTest {
         // fails)
         val failingFuture: CompletableFuture<Location> = CompletableFuture()
         failingFuture.completeExceptionally(RuntimeException(LocationManagerInterface.GET_LOCATION_EXCEPTION))
-        `when`(locationManagerMock.getCurrentLocation(anyOrNull())).thenReturn(
+        When(locationManagerMock.getCurrentLocation(anyOrNull())).thenReturn(
             failingFuture
         )
 

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/HelpPageActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/HelpPageActivityTest.kt
@@ -2,7 +2,6 @@ package com.github.h3lp3rs.h3lp
 
 import android.Manifest
 import android.content.Intent
-import android.location.Location
 import android.os.Bundle
 import androidx.test.core.app.ActivityScenario.*
 import androidx.test.core.app.ApplicationProvider
@@ -23,8 +22,6 @@ import com.github.h3lp3rs.h3lp.database.Databases.Companion.databaseOf
 import com.github.h3lp3rs.h3lp.database.MockDatabase
 import com.github.h3lp3rs.h3lp.dataclasses.EmergencyInformation
 import com.github.h3lp3rs.h3lp.dataclasses.HelperSkills
-import com.github.h3lp3rs.h3lp.locationmanager.GeneralLocationManager
-import com.github.h3lp3rs.h3lp.locationmanager.LocationManagerInterface
 import com.github.h3lp3rs.h3lp.signin.SignInActivity.Companion.globalContext
 import com.github.h3lp3rs.h3lp.signin.SignInActivity.Companion.userUid
 import com.github.h3lp3rs.h3lp.storage.Storages
@@ -36,12 +33,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.mock
-import org.mockito.kotlin.anyOrNull
-import java.util.*
-import java.util.concurrent.CompletableFuture.completedFuture
 import kotlin.collections.ArrayList
-import org.mockito.Mockito.`when` as When
 
 // Current coordinates to mock a user
 const val CURRENT_LAT = 46.514
@@ -56,9 +48,7 @@ const val TIME_TO_DESTINATION = "1 hour 19 mins"
 
 @RunWith(AndroidJUnit4::class)
 class HelpPageActivityTest : H3lpAppTest() {
-    private val locationManagerMock: LocationManagerInterface =
-        mock(LocationManagerInterface::class.java)
-    private val locationMock: Location = mock(Location::class.java)
+
     private val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
     private val helpId = 1
 
@@ -75,14 +65,7 @@ class HelpPageActivityTest : H3lpAppTest() {
 
     @Before
     fun init() {
-        // Mocking the location manager
-        When(locationManagerMock.getCurrentLocation(anyOrNull())).thenReturn(
-            completedFuture(locationMock)
-        )
-        When(locationMock.latitude).thenReturn(CURRENT_LAT)
-        When(locationMock.longitude).thenReturn(CURRENT_LONG)
-        GeneralLocationManager.set(locationManagerMock)
-
+        mockLocationToCoordinates(CURRENT_LAT, CURRENT_LONG)
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/HelpPageActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/HelpPageActivityTest.kt
@@ -35,14 +35,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.collections.ArrayList
 
-// Current coordinates to mock a user
-const val CURRENT_LAT = 46.514
-const val CURRENT_LONG = 6.604
-
-// Destination coordinates
-const val DESTINATION_LAT = 46.519
-const val DESTINATION_LONG = 6.667
-
 // Walking time from the user to the destination according to the Google directions API
 const val TIME_TO_DESTINATION = "1 hour 19 mins"
 
@@ -65,7 +57,7 @@ class HelpPageActivityTest : H3lpAppTest() {
 
     @Before
     fun init() {
-        mockLocationToCoordinates(CURRENT_LAT, CURRENT_LONG)
+        mockLocationToCoordinates(SWISS_LAT, SWISS_LONG)
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/HelpPageActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/HelpPageActivityTest.kt
@@ -1,9 +1,6 @@
 package com.github.h3lp3rs.h3lp
 
 import android.Manifest
-import android.app.Activity
-import android.app.Instrumentation
-import android.app.Instrumentation.*
 import android.content.Intent
 import android.location.Location
 import android.os.Bundle
@@ -13,9 +10,7 @@ import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.*
-import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.intent.matcher.IntentMatchers.*
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
@@ -36,7 +31,6 @@ import com.github.h3lp3rs.h3lp.storage.Storages
 import com.github.h3lp3rs.h3lp.storage.Storages.Companion.resetStorage
 import com.github.h3lp3rs.h3lp.storage.Storages.Companion.storageOf
 import junit.framework.TestCase.assertTrue
-import org.hamcrest.Matchers
 import org.hamcrest.Matchers.*
 import org.junit.Before
 import org.junit.Rule
@@ -49,7 +43,6 @@ import java.util.concurrent.CompletableFuture.completedFuture
 import kotlin.collections.ArrayList
 import org.mockito.Mockito.`when` as When
 
-const val EPIPEN = "Epipen"
 // Current coordinates to mock a user
 const val CURRENT_LAT = 46.514
 const val CURRENT_LONG = 6.604
@@ -58,13 +51,11 @@ const val CURRENT_LONG = 6.604
 const val DESTINATION_LAT = 46.519
 const val DESTINATION_LONG = 6.667
 
-const val TEST_TIMEOUT = 5000
-
 // Walking time from the user to the destination according to the Google directions API
 const val TIME_TO_DESTINATION = "1 hour 19 mins"
 
 @RunWith(AndroidJUnit4::class)
-class HelpPageActivityTest {
+class HelpPageActivityTest : H3lpAppTest() {
     private val locationManagerMock: LocationManagerInterface =
         mock(LocationManagerInterface::class.java)
     private val locationMock: Location = mock(Location::class.java)
@@ -166,10 +157,7 @@ class HelpPageActivityTest {
     @Test
     fun refusingAnEmergencyGoesBackToMainPage() {
         setupEmergencyAndDo {
-            Intents.init()
-            val i = Intent()
-            val intentResult = ActivityResult(Activity.RESULT_OK, i)
-            intending(anyIntent()).respondWith(intentResult)
+            initIntentAndCheckResponse()
             // Reject
             onView(withId(R.id.button_reject)).perform(click())
             intended(allOf(hasComponent(MainPageActivity::class.java.name)))
@@ -185,24 +173,28 @@ class HelpPageActivityTest {
         bundle.putStringArrayList(EXTRA_HELP_REQUIRED_PARAMETERS, arrayListOf(EPIPEN))
         bundle.putDouble(EXTRA_DESTINATION_LAT, 1.0)
         bundle.putDouble(EXTRA_DESTINATION_LONG, 1.0)
+
         val intent = Intent(
             getApplicationContext(),
             HelpPageActivity::class.java
         ).apply {
             putExtras(bundle)
         }
+
         // Setup the database accordingly
         globalContext = getApplicationContext()
         userUid = USER_TEST_ID
+
         resetStorage()
         PREFERENCES.db = MockDatabase()
         val emergencyDb = MockDatabase()
-        val skills = HelperSkills(true, true, true, true,
-            true, true)
-        val emergency = EmergencyInformation(helpId.toString(), 2.0, 2.0, skills,
-            ArrayList(listOf("Epipen")), Date(), null, ArrayList())
+
+        val skills = EPIPEN_SKILL
+        val emergency = EPIPEN_EMERGENCY_INFO
+
         emergencyDb.setObject(helpId.toString(), EmergencyInformation::class.java, emergency)
         EMERGENCIES.db = emergencyDb
+
         // Setup skills storage accordingly
         storageOf(Storages.SKILLS).setObject(globalContext.getString(R.string.my_skills_key),
             HelperSkills::class.java, skills)

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/HelpParametersActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/HelpParametersActivityTest.kt
@@ -45,9 +45,6 @@ private val CORRECT_EMERGENCY_CALL = Triple(6.632, 46.519, "144")
 
 @RunWith(AndroidJUnit4::class)
 class HelpParametersActivityTest : H3lpAppTest() {
-    private val locationManagerMock: LocationManagerInterface =
-        mock(LocationManagerInterface::class.java)
-    private val locationMock: Location = mock(Location::class.java)
 
     @get:Rule
     val testRule = ActivityScenarioRule(
@@ -103,12 +100,7 @@ class HelpParametersActivityTest : H3lpAppTest() {
 
     @Test
     fun clickPhoneButtonAndContactButtonDialsEmergencyContactNumber() {
-        When(locationManagerMock.getCurrentLocation(anyOrNull())).thenReturn(
-            completedFuture(
-                locationMock
-            )
-        )
-        GeneralLocationManager.set(locationManagerMock)
+        mockEmptyLocation()
 
         loadValidMedicalDataToStorage()
 
@@ -135,13 +127,7 @@ class HelpParametersActivityTest : H3lpAppTest() {
 
     @Test
     fun clickPhoneButtonDialsCorrectEmergencyNumber() {
-        // Mocking the user's location to a predefined set of coordinates
-        When(locationManagerMock.getCurrentLocation(anyOrNull())).thenReturn(
-            completedFuture(locationMock)
-        )
-        When(locationMock.longitude).thenReturn(CORRECT_EMERGENCY_CALL.first)
-        When(locationMock.latitude).thenReturn(CORRECT_EMERGENCY_CALL.second)
-        GeneralLocationManager.set(locationManagerMock)
+        mockLocationToCoordinates(CORRECT_EMERGENCY_CALL.first, CORRECT_EMERGENCY_CALL.second)
 
         loadValidMedicalDataToStorage()
 
@@ -172,15 +158,7 @@ class HelpParametersActivityTest : H3lpAppTest() {
     fun clickPhoneButtonWithNoLocationDialsDefaultEmergencyNumber() {
         loadValidMedicalDataToStorage()
 
-        // Mocking the location manager as if an error occurred (in which case, the returned future
-        // fails)
-        val failingFuture: CompletableFuture<Location> = CompletableFuture()
-        failingFuture.completeExceptionally(RuntimeException(GET_LOCATION_EXCEPTION))
-        When(locationManagerMock.getCurrentLocation(anyOrNull())).thenReturn(
-            failingFuture
-        )
-
-        GeneralLocationManager.set(locationManagerMock)
+        mockFailingLocation()
 
         val phoneButton = onView(withId(R.id.help_params_call_button))
 
@@ -261,13 +239,7 @@ class HelpParametersActivityTest : H3lpAppTest() {
 
     @Test
     fun screenDisplaysCorrectLocation() {
-        // Mocking the user's location to a predefined set of coordinates
-        When(locationManagerMock.getCurrentLocation(anyOrNull())).thenReturn(
-            completedFuture(locationMock)
-        )
-        When(locationMock.longitude).thenReturn(CORRECT_EMERGENCY_CALL.first)
-        When(locationMock.latitude).thenReturn(CORRECT_EMERGENCY_CALL.second)
-        GeneralLocationManager.set(locationManagerMock)
+        mockLocationToCoordinates(CORRECT_EMERGENCY_CALL.first, CORRECT_EMERGENCY_CALL.second)
 
         // Checking that the user's actual location is displayed before they call an ambulance
         val locationInformation = onView(withId(R.id.location_information))

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/HelpParametersActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/HelpParametersActivityTest.kt
@@ -2,7 +2,6 @@ package com.github.h3lp3rs.h3lp
 
 import android.Manifest
 import android.content.Intent
-import android.location.Location
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.espresso.Espresso.onView
@@ -20,8 +19,6 @@ import com.github.h3lp3rs.h3lp.database.Databases.EMERGENCIES
 import com.github.h3lp3rs.h3lp.database.Databases.NEW_EMERGENCIES
 import com.github.h3lp3rs.h3lp.database.MockDatabase
 import com.github.h3lp3rs.h3lp.locationmanager.GeneralLocationManager
-import com.github.h3lp3rs.h3lp.locationmanager.LocationManagerInterface
-import com.github.h3lp3rs.h3lp.locationmanager.LocationManagerInterface.Companion.GET_LOCATION_EXCEPTION
 import com.github.h3lp3rs.h3lp.signin.SignInActivity.Companion.globalContext
 import com.github.h3lp3rs.h3lp.signin.SignInActivity.Companion.userUid
 import com.github.h3lp3rs.h3lp.storage.Storages
@@ -33,15 +30,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.mock
-import org.mockito.kotlin.anyOrNull
-import java.lang.RuntimeException
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletableFuture.completedFuture
-import org.mockito.Mockito.`when` as When
 
 // Case example of a possible query when a user clicks on the call for emergency button
-private val CORRECT_EMERGENCY_CALL = Triple(6.632, 46.519, "144")
 
 @RunWith(AndroidJUnit4::class)
 class HelpParametersActivityTest : H3lpAppTest() {
@@ -127,7 +117,7 @@ class HelpParametersActivityTest : H3lpAppTest() {
 
     @Test
     fun clickPhoneButtonDialsCorrectEmergencyNumber() {
-        mockLocationToCoordinates(CORRECT_EMERGENCY_CALL.first, CORRECT_EMERGENCY_CALL.second)
+        mockLocationToCoordinates(SWISS_LONG, SWISS_LAT)
 
         loadValidMedicalDataToStorage()
 
@@ -142,7 +132,7 @@ class HelpParametersActivityTest : H3lpAppTest() {
             .perform(click())
 
         // The expected ambulance phone number given the location (specified by the coordinates)
-        val number = "tel:${CORRECT_EMERGENCY_CALL.third}"
+        val number = "tel:${SWISS_EMERGENCY_NUMBER}"
 
         // Checking that this emergency number is dialed
         intended(
@@ -239,14 +229,14 @@ class HelpParametersActivityTest : H3lpAppTest() {
 
     @Test
     fun screenDisplaysCorrectLocation() {
-        mockLocationToCoordinates(CORRECT_EMERGENCY_CALL.first, CORRECT_EMERGENCY_CALL.second)
+        mockLocationToCoordinates(SWISS_LONG, SWISS_LAT)
 
         // Checking that the user's actual location is displayed before they call an ambulance
         val locationInformation = onView(withId(R.id.location_information))
         locationInformation
-            .check(matches(withText(containsString(CORRECT_EMERGENCY_CALL.first.toString()))))
+            .check(matches(withText(containsString(SWISS_LONG.toString()))))
         locationInformation
-            .check(matches(withText(containsString(CORRECT_EMERGENCY_CALL.second.toString()))))
+            .check(matches(withText(containsString(SWISS_LAT.toString()))))
     }
 
     @After

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/MedicalCardActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/MedicalCardActivityTest.kt
@@ -38,9 +38,8 @@ import org.junit.runner.RunWith
 import java.util.*
 
 @RunWith(AndroidJUnit4::class)
-class MedicalCardActivityTest {
+class MedicalCardActivityTest : H3lpAppTest() {
     private val ctx: Context = getApplicationContext()
-    private val validNumbers = arrayOf("0216933000", "216933000", "+41216933000")
 
     private fun launch(): ActivityScenario<MedicalCardActivity> {
         return launch(Intent(getApplicationContext(), MedicalCardActivity::class.java))
@@ -48,17 +47,10 @@ class MedicalCardActivityTest {
 
     private fun launchAndDo(action: () -> Unit) {
         launch().use {
-            start()
+            initIntentAndCheckResponse()
             action()
             end()
         }
-    }
-
-    private fun start() {
-        init()
-        val intent = Intent()
-        val intentResult = ActivityResult(Activity.RESULT_OK, intent)
-        intending(anyIntent()).respondWith(intentResult)
     }
 
     private fun end() {
@@ -69,6 +61,7 @@ class MedicalCardActivityTest {
     fun setup() {
         globalContext = getApplicationContext()
         userUid = USER_TEST_ID
+
         setDatabase(PREFERENCES, MockDatabase())
         resetStorage()
         storageOf(Storages.USER_COOKIE).setBoolean(GUIDE_KEY, true)
@@ -124,7 +117,7 @@ class MedicalCardActivityTest {
     @Test
     fun validPhoneNumberDoesNotLeadToError(){
         launchAndDo {
-            for (validNumber in validNumbers) {
+            for (validNumber in VALID_FORMAT_NUMBERS) {
                 onView(withId(R.id.medicalInfoContactNumberEditTxt))
                     .perform(scrollTo(), replaceText(validNumber))
                 onView(withId(R.id.medicalInfoContactNumberTxtLayout)).check(
@@ -276,7 +269,7 @@ class MedicalCardActivityTest {
         onView(withId(R.id.medicalInfoGenderDropdown))
             .perform(replaceText(Gender.Male.name))
         onView(withId(R.id.medicalInfoContactNumberEditTxt))
-            .perform(scrollTo(), replaceText(validNumbers[0]))
+            .perform(scrollTo(), replaceText(VALID_CONTACT_NUMBER))
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/MySkillsActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/MySkillsActivityTest.kt
@@ -26,7 +26,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class MySkillsActivityTest {
+class MySkillsActivityTest : H3lpAppTest() {
 
     private fun launch(): ActivityScenario<MySkillsActivity> {
         return launch(Intent(getApplicationContext(), MySkillsActivity::class.java))
@@ -36,6 +36,7 @@ class MySkillsActivityTest {
     fun dataInit() {
         globalContext = getApplicationContext()
         userUid = USER_TEST_ID
+
         setDatabase(PREFERENCES, MockDatabase())
         resetStorage()
     }
@@ -43,12 +44,11 @@ class MySkillsActivityTest {
     @Test
     fun backButtonWorks() {
         launch().use {
-            init()
-            val intent = Intent()
-            val intentResult = ActivityResult(Activity.RESULT_OK, intent)
-            intending(anyIntent()).respondWith(intentResult)
+            initIntentAndCheckResponse()
             onView(withId(R.id.mySkillsBackButton)).perform(click())
+
             intended(allOf(hasComponent(MainPageActivity::class.java.name)))
+
             release()
         }
     }
@@ -58,6 +58,7 @@ class MySkillsActivityTest {
         launch().use {
             onView(withId(R.id.mySkillsHelpButton))
                 .perform(click())
+
             onView(withText(R.string.my_helper_skills))
                 .inRoot(RootMatchers.isDialog())
                 .check(ViewAssertions.matches(isDisplayed()))

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/NearbyUtilitiesActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/NearbyUtilitiesActivityTest.kt
@@ -32,30 +32,34 @@ class NearbyUtilitiesActivityTest {
     )
 
     @get:Rule
-    var mRuntimePermissionRule: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION)
+    var mRuntimePermissionRule: GrantPermissionRule =
+        GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION)
 
     @Before
-    fun setup(){
+    fun setup() {
         globalContext = getApplicationContext()
     }
 
     @Test
     fun canLaunchMapWithPharmacyRequest() {
         val utility = R.string.nearby_phamacies
+
         val intent = Intent(
-            ApplicationProvider.getApplicationContext(),
+            getApplicationContext(),
             NearbyUtilitiesActivity::class.java
         ).apply {
             putExtra(EXTRA_NEARBY_UTILITIES, utility)
         }
+
         canLaunchMap(intent)
     }
 
     @Test
     fun canLaunchMapWithHospitalRequest() {
         val utility = R.string.nearby_hospitals
+
         val intent = Intent(
-            ApplicationProvider.getApplicationContext(),
+            getApplicationContext(),
             NearbyUtilitiesActivity::class.java
         ).apply {
             putExtra(EXTRA_NEARBY_UTILITIES, utility)
@@ -82,10 +86,8 @@ class NearbyUtilitiesActivityTest {
 
     private fun canLaunchMap(intent: Intent) {
         launch<NearbyUtilitiesActivity>(intent).use {
-            launch<NearbyUtilitiesActivity>(intent).use {
-                onView(ViewMatchers.withId(R.id.mapNearbyUtilities))
-                    .check(matches(isDisplayed()))
-            }
+            onView(ViewMatchers.withId(R.id.mapNearbyUtilities))
+                .check(matches(isDisplayed()))
         }
     }
 

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/NearbyUtilitiesActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/NearbyUtilitiesActivityTest.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Intent
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -12,6 +13,8 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
+import com.github.h3lp3rs.h3lp.signin.SignInActivity.Companion.globalContext
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -30,6 +33,11 @@ class NearbyUtilitiesActivityTest {
 
     @get:Rule
     var mRuntimePermissionRule: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION)
+
+    @Before
+    fun setup(){
+        globalContext = getApplicationContext()
+    }
 
     @Test
     fun canLaunchMapWithPharmacyRequest() {

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/NotificationTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/NotificationTest.kt
@@ -21,7 +21,7 @@ import org.junit.Test
  * Should use uiDevice instead of espresso to be able to test element outside the scope of application
  */
 
-class NotificationTest {
+class NotificationTest : H3lpAppTest(){
 
     private val ctx: Context = ApplicationProvider.getApplicationContext()
     private val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
@@ -43,7 +43,7 @@ class NotificationTest {
         NotificationService.sendSimpleNotification(ctx,TITLE,DESCRIPTION)
 
         uiDevice.openNotification()
-        uiDevice.wait(Until.hasObject(By.textStartsWith("H3LP")),3000)
+        uiDevice.wait(Until.hasObject(By.textStartsWith("H3LP")), TEST_TIMEOUT)
 
         val title : UiObject2=uiDevice.findObject(By.text(TITLE))
         val description : UiObject2=uiDevice.findObject(By.text(DESCRIPTION))
@@ -62,8 +62,10 @@ class NotificationTest {
 
         val title : UiObject2=uiDevice.findObject(By.text(TITLE))
         val description : UiObject2=uiDevice.findObject(By.text(DESCRIPTION))
+
         assertEquals(title.text,TITLE)
         assertEquals(description.text,DESCRIPTION)
+
         title.click()
         uiDevice.findObject(By.textStartsWith(ctx.getString(R.string.my_helper_skills)))
 
@@ -78,7 +80,8 @@ class NotificationTest {
      */
     private fun clearAllNotifications() {
         uiDevice.openNotification()
-        uiDevice.wait(Until.hasObject(By.textStartsWith("H3LP")), 1000)
+        uiDevice.wait(Until.hasObject(By.textStartsWith("H3LP")), TEST_TIMEOUT)
+
         val clearAll: UiObject2 = uiDevice.findObject(By.textStartsWith("Clear all"))
         clearAll.click()
     }

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/SearchBarTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/SearchBarTest.kt
@@ -1,7 +1,6 @@
 package com.github.h3lp3rs.h3lp
 
-import android.app.Activity.RESULT_OK
-import android.app.Instrumentation.*
+
 import android.content.Intent
 import android.view.KeyEvent
 import android.widget.AutoCompleteTextView
@@ -16,7 +15,6 @@ import androidx.test.espresso.intent.Intents.*
 import androidx.test.espresso.intent.matcher.IntentMatchers.*
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.h3lp3rs.h3lp.database.Databases
 import com.github.h3lp3rs.h3lp.database.Databases.*
 import com.github.h3lp3rs.h3lp.database.Databases.Companion.setDatabase
 import com.github.h3lp3rs.h3lp.database.MockDatabase
@@ -34,7 +32,7 @@ import org.junit.runner.RunWith
 private const val NONEXISTENT_ITEM = "Nonexistent item"
 
 @RunWith(AndroidJUnit4::class)
-class SearchBarTest {
+class SearchBarTest : H3lpAppTest() {
 
     private fun launch(): ActivityScenario<MainPageActivity> {
         return launch(Intent(getApplicationContext(), MainPageActivity::class.java))
@@ -42,7 +40,7 @@ class SearchBarTest {
 
     private fun launchAndDo(action: () -> Unit) {
         launch().use {
-            start()
+            initIntentAndCheckResponse()
             action()
             end()
         }
@@ -55,13 +53,6 @@ class SearchBarTest {
         setDatabase(PREFERENCES, MockDatabase())
         resetStorage()
         storageOf(USER_COOKIE).setBoolean(GUIDE_KEY, true)
-    }
-
-    private fun start() {
-        init()
-        val intent = Intent()
-        val intentResult = ActivityResult(RESULT_OK, intent)
-        intending(anyIntent()).respondWith(intentResult)
     }
 
     private fun end() {

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/SettingsActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/SettingsActivityTest.kt
@@ -28,8 +28,7 @@ import org.junit.runner.RunWith
 import java.lang.NullPointerException
 
 @RunWith(AndroidJUnit4::class)
-class SettingsActivityTest {
-
+class SettingsActivityTest : H3lpAppTest() {
 
     private fun launch(): ActivityScenario<SettingsActivity> {
         return launch(Intent(getApplicationContext(), SettingsActivity::class.java))
@@ -46,10 +45,7 @@ class SettingsActivityTest {
     @Test
     fun backButtonWorks() {
         launch().use {
-            init()
-            val intent = Intent()
-            val intentResult = ActivityResult(Activity.RESULT_OK, intent)
-            intending(anyIntent()).respondWith(intentResult)
+            initIntentAndCheckResponse()
             onView(withId(R.id.settingsBackButton)).perform(click())
             intended(allOf(hasComponent(MainPageActivity::class.java.name)))
             release()
@@ -59,10 +55,7 @@ class SettingsActivityTest {
     @Test
     fun logoutButtonWorks() {
         launch().use {
-            init()
-            val intent = Intent()
-            val intentResult = ActivityResult(Activity.RESULT_OK, intent)
-            intending(anyIntent()).respondWith(intentResult)
+            initIntentAndCheckResponse()
             onView(withId(R.id.logoutSettingsButton)).perform(click())
             intended(allOf(hasComponent(SignInActivity::class.java.name)))
             release()

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/SideBarTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/SideBarTest.kt
@@ -1,8 +1,5 @@
 package com.github.h3lp3rs.h3lp
 
-import android.app.Activity
-import android.app.Instrumentation.*
-import android.content.Intent
 import android.view.Gravity
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.ViewInteraction
@@ -25,7 +22,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class SideBarTest {
+class SideBarTest : H3lpAppTest() {
     @get:Rule
     val testRule = ActivityScenarioRule(
         MainPageActivity::class.java
@@ -33,10 +30,7 @@ class SideBarTest {
 
     @Before
     fun setup() {
-        init()
-        val intent = Intent()
-        val intentResult = ActivityResult(Activity.RESULT_OK, intent)
-        intending(anyIntent()).respondWith(intentResult)
+        initIntentAndCheckResponse()
     }
 
     @After
@@ -74,7 +68,7 @@ class SideBarTest {
         openDrawerLayout()
         onView(withId(R.id.nav_view))
             .perform(NavigationViewActions.navigateTo(R.id.nav_home))
-        Thread.sleep(500)
+        Thread.sleep(WAIT_UI)
         drawerLayout?.check(matches(isClosed()))
     }
 

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/StorageTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/StorageTest.kt
@@ -16,9 +16,7 @@ import org.junit.Before
 import org.junit.Test
 import kotlin.random.Random
 
-const val USER_TEST_ID = "SECRET_AGENT_007"
-
-class StorageTest {
+class StorageTest : H3lpAppTest() {
 
     // Dummy class for complex types
     private data class Foo(val a1: Int, val a2: String)
@@ -63,9 +61,12 @@ class StorageTest {
         val int = TEST_SEED.nextInt()
         storage.setInt(TEST_KEY, int)
         storage.setInt(TEST_KEY + "1", int + 1)
+
         assertEquals(int, storage.getIntOrDefault(TEST_KEY, int))
         assertEquals(int + 1, storage.getIntOrDefault(TEST_KEY + "1", int + 1))
+
         resetStorage()
+
         assertEquals(int - 2, storage.getIntOrDefault(TEST_KEY, int - 2))
         assertEquals(int - 2, storage.getIntOrDefault(TEST_KEY + "1", int - 2))
     }
@@ -73,11 +74,14 @@ class StorageTest {
     @Test
     fun pushAndPullWorksProperly() {
         assertEquals(-1, storage.getIntOrDefault(TEST_KEY, -1))
+
         storage.setInt(TEST_KEY, 0)
         assertEquals(0, storage.getIntOrDefault(TEST_KEY, -1))
+
         storage.push()
         resetStorage()
         assertEquals(-1, storage.getIntOrDefault(TEST_KEY, -1))
+
         storage.pull()
         assertEquals(0, storage.getIntOrDefault(TEST_KEY, -1))
     }

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/ToolbarTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/ToolbarTest.kt
@@ -27,7 +27,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class ToolbarTest {
+class ToolbarTest : H3lpAppTest() {
 
     @get:Rule
     val testRule = ActivityScenarioRule(
@@ -36,10 +36,7 @@ class ToolbarTest {
 
     @Before
     fun setup() {
-        init()
-        val intent = Intent()
-        val intentResult = ActivityResult(RESULT_OK, intent)
-        intending(anyIntent()).respondWith(intentResult)
+        initIntentAndCheckResponse()
     }
 
     @After

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/presentation/PresIrrelevantActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/presentation/PresIrrelevantActivityTest.kt
@@ -35,7 +35,7 @@ import com.github.h3lp3rs.h3lp.storage.Storages.Companion.resetStorage
 import com.github.h3lp3rs.h3lp.storage.Storages.Companion.storageOf
 
 @RunWith(AndroidJUnit4::class)
-class PresIrrelevantActivityTest {
+class PresIrrelevantActivityTest : H3lpAppTest() {
 
     private fun alreadyAccepted() {
         storageOf(USER_COOKIE).setBoolean(globalContext.getString(R.string.KEY_USER_AGREE), true)
@@ -70,10 +70,7 @@ class PresIrrelevantActivityTest {
     }
 
     private fun checkLaunchOnApprovalClick(activity: String) {
-        init()
-        val i = Intent()
-        val intentResult = ActivityResult(Activity.RESULT_OK, i)
-        intending(anyIntent()).respondWith(intentResult)
+        initIntentAndCheckResponse()
         onView(withId(R.id.pres3_button)).perform(click())
         intended(allOf(hasComponent(activity)))
         release()
@@ -121,10 +118,7 @@ class PresIrrelevantActivityTest {
     @Test
     fun unsuccessfulApprovalButtonNeverApproved() {
         launch().use {
-            init()
-            val i = Intent()
-            val intentResult = ActivityResult(Activity.RESULT_OK, i)
-            intending(anyIntent()).respondWith(intentResult)
+            initIntentAndCheckResponse()
             onView(withId(R.id.pres3_button)).perform(click())
             assertThat(getIntents().size, `is`(0))
             release()
@@ -166,10 +160,7 @@ class PresIrrelevantActivityTest {
     @Test
     fun tosAreLaunched() {
         launch().use {
-            init()
-            val i = Intent()
-            val intentResult = ActivityResult(Activity.RESULT_OK, i)
-            intending(anyIntent()).respondWith(intentResult)
+            initIntentAndCheckResponse()
             // Kind of ugly but Espresso being Espresso
             onView(withId(R.id.pres3_checkBox)).perform(clickPercent(0.9f, 0.5f))
             intended(allOf(hasComponent(ToSActivity::class.java.name)))

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/professional/ProMainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/professional/ProMainActivityTest.kt
@@ -1,9 +1,5 @@
 package com.github.h3lp3rs.h3lp.professional
 
-import android.app.Activity
-import android.app.Instrumentation
-import android.content.Intent
-import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions
@@ -12,6 +8,7 @@ import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.h3lp3rs.h3lp.H3lpAppTest
 import com.github.h3lp3rs.h3lp.R
 import org.hamcrest.Matchers
 import org.junit.Rule
@@ -19,7 +16,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class ProMainActivityTest {
+class ProMainActivityTest : H3lpAppTest() {
 
     @get:Rule
     val testRule = ActivityScenarioRule(
@@ -40,14 +37,12 @@ class ProMainActivityTest {
 
     @Test
     fun profileButtonWorks() {
-            Intents.init()
-            val intent = Intent()
-            val intentResult = Instrumentation.ActivityResult(Activity.RESULT_OK, intent)
-            Intents.intending(IntentMatchers.anyIntent()).respondWith(intentResult)
-            Espresso.onView(ViewMatchers.withId(R.id.pro_profile_button))
-                .perform(ViewActions.click())
-            Intents.intended(Matchers.allOf(IntentMatchers.hasComponent(ProfessionalTypeSelection::class.java.name)))
-            Intents.release()
+        initIntentAndCheckResponse()
+        Espresso.onView(ViewMatchers.withId(R.id.pro_profile_button))
+            .perform(ViewActions.click())
+        Intents.intended(Matchers.allOf(IntentMatchers.hasComponent(ProfessionalTypeSelection::class.java.name)))
+
+        Intents.release()
     }
    /* This test fails on Cirrus because buttons can't be found
    @Test

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/professional/ProfessionalTypeSelectionTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/professional/ProfessionalTypeSelectionTest.kt
@@ -1,7 +1,5 @@
 package com.github.h3lp3rs.h3lp.professional
 
-import android.app.Activity
-import android.app.Instrumentation.*
 import android.content.Intent
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ActivityScenario.*
@@ -14,9 +12,9 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.*
 import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.h3lp3rs.h3lp.H3lpAppTest
 import com.github.h3lp3rs.h3lp.MySkillsActivity
 import com.github.h3lp3rs.h3lp.R
-import com.github.h3lp3rs.h3lp.USER_TEST_ID
 import com.github.h3lp3rs.h3lp.database.Databases.*
 import com.github.h3lp3rs.h3lp.database.Databases.Companion.setDatabase
 import com.github.h3lp3rs.h3lp.database.MockDatabase
@@ -29,7 +27,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class ProfessionalTypeSelectionTest {
+class ProfessionalTypeSelectionTest : H3lpAppTest() {
 
     private fun launch(): ActivityScenario<MySkillsActivity> {
         return launch(Intent(getApplicationContext(), ProfessionalTypeSelection::class.java))
@@ -46,10 +44,7 @@ class ProfessionalTypeSelectionTest {
     @Test
     fun backButtonWorks() {
         launch().use {
-            init()
-            val intent = Intent()
-            val intentResult = ActivityResult(Activity.RESULT_OK, intent)
-            intending(anyIntent()).respondWith(intentResult)
+            initIntentAndCheckResponse()
             onView(withId(R.id.myProTypeBackButton)).perform(click())
             intended(allOf(hasComponent(ProMainActivity::class.java.name)))
             release()

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/professional/VerificationActivityTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/professional/VerificationActivityTest.kt
@@ -13,6 +13,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.h3lp3rs.h3lp.H3lpAppTest
 import com.github.h3lp3rs.h3lp.R
 import com.github.h3lp3rs.h3lp.database.Databases
 import com.github.h3lp3rs.h3lp.database.MockDatabase
@@ -28,12 +29,8 @@ import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 
-private val TEST_URI = Uri.EMPTY
-private const val TEST_STRING = ""
-private const val INTENT_TYPE = "image/*"
-
 @RunWith(AndroidJUnit4::class)
-class VerificationActivityTest {
+class VerificationActivityTest : H3lpAppTest() {
 
     @get:Rule
     val testRule = ActivityScenarioRule(
@@ -57,7 +54,7 @@ class VerificationActivityTest {
                 isDisplayed()
             )
         ).perform(ViewActions.click())
-        intended(hasType(INTENT_TYPE))
+        intended(hasType(IMAGE_INTENT))
         intended(hasAction(Intent.ACTION_GET_CONTENT))
     }
 

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/signin/GoogleSignInTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/signin/GoogleSignInTest.kt
@@ -11,9 +11,8 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasPackage
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.h3lp3rs.h3lp.H3lpAppTest
 import com.github.h3lp3rs.h3lp.R
-import com.github.h3lp3rs.h3lp.USER_TEST_ID
-import com.github.h3lp3rs.h3lp.database.Databases
 import com.github.h3lp3rs.h3lp.database.Databases.*
 import com.github.h3lp3rs.h3lp.database.Databases.Companion.setDatabase
 import com.github.h3lp3rs.h3lp.database.MockDatabase
@@ -34,7 +33,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.Mockito.`when` as When
 
 @RunWith(AndroidJUnit4::class)
-class GoogleSignInTest {
+class GoogleSignInTest : H3lpAppTest() {
     private lateinit var intent: Intent
     private val googleSignInPackageName = "com.google.android.gms"
     private var authenticationStarted = false
@@ -47,8 +46,10 @@ class GoogleSignInTest {
     @Before
     fun setUp() {
         init()
+
         globalContext = getApplicationContext()
         userUid = USER_TEST_ID
+
         setDatabase(PREFERENCES, MockDatabase())
         resetStorage()
 

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/signin/NewUserSignInTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/signin/NewUserSignInTest.kt
@@ -3,7 +3,6 @@ package com.github.h3lp3rs.h3lp.signin
 import android.app.Activity
 import android.content.Intent
 import androidx.activity.result.ActivityResult
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.core.app.ApplicationProvider.*
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
@@ -12,9 +11,8 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.h3lp3rs.h3lp.H3lpAppTest
 import com.github.h3lp3rs.h3lp.R
-import com.github.h3lp3rs.h3lp.USER_TEST_ID
-import com.github.h3lp3rs.h3lp.database.Databases
 import com.github.h3lp3rs.h3lp.database.Databases.*
 import com.github.h3lp3rs.h3lp.database.Databases.Companion.setDatabase
 import com.github.h3lp3rs.h3lp.database.MockDatabase
@@ -34,7 +32,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.Mockito.`when` as When
 
 @RunWith(AndroidJUnit4::class)
-class NewUserSignInTest {
+class NewUserSignInTest : H3lpAppTest() {
 
     private lateinit var intent: Intent
     private var authenticationStarted = false
@@ -47,8 +45,10 @@ class NewUserSignInTest {
     @Before
     fun setUp() {
         init()
+
         globalContext = getApplicationContext()
         userUid = USER_TEST_ID
+
         setDatabase(PREFERENCES, MockDatabase())
         resetStorage()
 
@@ -58,6 +58,7 @@ class NewUserSignInTest {
         testRule.scenario.onActivity { activity ->
             intent = Intent(getApplicationContext(), activity.javaClass)
             val taskMock = mock(Task::class.java)
+
             When(taskMock.isSuccessful).thenReturn(true)
             When(taskMock.isComplete).thenReturn(true)
             When(signInMock.signIn(activity)).thenReturn(intent)
@@ -80,6 +81,7 @@ class NewUserSignInTest {
     @Test
     fun newUserSignInLaunchesAuthenticationProcess() {
         clickSignInButton()
+
         testRule.scenario.onActivity { activity ->
             activity.authenticateUser(
                 ActivityResult(
@@ -88,6 +90,7 @@ class NewUserSignInTest {
                 ), activity
             )
         }
+
         assertEquals(authenticationStarted, true)
     }
 

--- a/app/src/androidTest/java/com/github/h3lp3rs/h3lp/signin/SignedInUserTest.kt
+++ b/app/src/androidTest/java/com/github/h3lp3rs/h3lp/signin/SignedInUserTest.kt
@@ -9,10 +9,9 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.h3lp3rs.h3lp.H3lpAppTest
 import com.github.h3lp3rs.h3lp.MainPageActivity
 import com.github.h3lp3rs.h3lp.R
-import com.github.h3lp3rs.h3lp.USER_TEST_ID
-import com.github.h3lp3rs.h3lp.database.Databases
 import com.github.h3lp3rs.h3lp.database.Databases.*
 import com.github.h3lp3rs.h3lp.database.Databases.Companion.setDatabase
 import com.github.h3lp3rs.h3lp.database.MockDatabase
@@ -34,7 +33,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.Mockito.`when` as When
 
 @RunWith(AndroidJUnit4::class)
-class SignedInUserTest {
+class SignedInUserTest : H3lpAppTest() {
 
     @get:Rule
     val testRule = ActivityScenarioRule(
@@ -44,8 +43,10 @@ class SignedInUserTest {
     @Before
     fun setUp() {
         init()
+
         globalContext = getApplicationContext()
         userUid = USER_TEST_ID
+
         setDatabase(PREFERENCES, MockDatabase())
         resetStorage()
 
@@ -55,6 +56,7 @@ class SignedInUserTest {
         testRule.scenario.onActivity { activity ->
             val intent = Intent(getApplicationContext(), activity.javaClass)
             val taskMock = Mockito.mock(Task::class.java)
+
             When(taskMock.isSuccessful).thenReturn(true)
             When(taskMock.isComplete).thenReturn(true)
             When(signInMock.signIn(activity)).thenReturn(intent)
@@ -69,6 +71,7 @@ class SignedInUserTest {
     fun signedInUserMovesToMainPageIfToSAccepted() {
         storageOf(USER_COOKIE).setBoolean(globalContext.getString(R.string.KEY_USER_AGREE), true)
         onView(withId(R.id.signInButton)).perform(click())
+
         intended(hasComponent(MainPageActivity::class.java.name))
     }
 
@@ -76,6 +79,7 @@ class SignedInUserTest {
     fun signedInUserMovesToPresentationIfToSNotAccepted() {
         storageOf(USER_COOKIE).setBoolean(globalContext.getString(R.string.KEY_USER_AGREE), false)
         onView(withId(R.id.signInButton)).perform(click())
+
         intended(hasComponent(PresArrivalActivity::class.java.name))
     }
 

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/AwaitHelpActivity.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/AwaitHelpActivity.kt
@@ -1,5 +1,6 @@
 package com.github.h3lp3rs.h3lp
 
+import LocationHelper
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -22,7 +23,6 @@ import com.github.h3lp3rs.h3lp.firstaid.AedActivity
 import com.github.h3lp3rs.h3lp.firstaid.AllergyActivity
 import com.github.h3lp3rs.h3lp.firstaid.AsthmaActivity
 import com.github.h3lp3rs.h3lp.firstaid.HeartAttackActivity
-import com.github.h3lp3rs.h3lp.locationmanager.GeneralLocationManager
 import com.github.h3lp3rs.h3lp.messaging.RecentMessagesActivity
 import com.github.h3lp3rs.h3lp.storage.Storages
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
@@ -35,8 +35,10 @@ import kotlinx.android.synthetic.main.activity_await_help.*
  */
 class AwaitHelpActivity : AppCompatActivity() {
 
-    private var currentLong : Double = 0.0
-    private var currentLat : Double = 0.0
+//    private var currentLong : Double = 0.0
+//    private var currentLat : Double = 0.0
+    private val locationHelper = LocationHelper()
+
     private val askedMeds : List<String> = listOf()
     private var helpersNumbers = 0
     private val helpersId = ArrayList<String>()
@@ -51,7 +53,8 @@ class AwaitHelpActivity : AppCompatActivity() {
 
         apiHelper = GoogleAPIHelper(resources.getString(R.string.google_maps_key))
 
-        setupLocation()
+        locationHelper.updateCoordinates(this)
+        //setupLocation()
 
         val bundle = intent.extras
         if (bundle != null) {
@@ -161,19 +164,6 @@ class AwaitHelpActivity : AppCompatActivity() {
     }
 
     /**
-     * Initializes the user's current location or leaves it to null in case a mistake occurred
-     * during the location information retrieval (so that the fallback emergency services number
-     * can still be called)
-     */
-    private fun setupLocation() {
-        val futureLocation = GeneralLocationManager.get().getCurrentLocation(this)
-        futureLocation.thenAccept { location ->
-            currentLat = location.latitude
-            currentLong = location.longitude
-        }
-    }
-
-    /**
      *  Called when the user presses the emergency call button. Opens a pop-up
      *  asking the user to choose whether they want to call local emergency
      *  services or their emergency contact, and dials the correct number.
@@ -225,7 +215,7 @@ class AwaitHelpActivity : AppCompatActivity() {
      */
     private fun launchEmergencyCall() {
         val emergencyNumber = LocalEmergencyCaller.getLocalEmergencyNumber(
-            currentLong, currentLat, this
+            locationHelper.getUserLongitude(), locationHelper.getUserLatitude(), this
         )
 
         val dial = "tel:$emergencyNumber"

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/AwaitHelpActivity.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/AwaitHelpActivity.kt
@@ -35,8 +35,6 @@ import kotlinx.android.synthetic.main.activity_await_help.*
  */
 class AwaitHelpActivity : AppCompatActivity() {
 
-//    private var currentLong : Double = 0.0
-//    private var currentLat : Double = 0.0
     private val locationHelper = LocationHelper()
 
     private val askedMeds : List<String> = listOf()
@@ -54,7 +52,6 @@ class AwaitHelpActivity : AppCompatActivity() {
         apiHelper = GoogleAPIHelper(resources.getString(R.string.google_maps_key))
 
         locationHelper.updateCoordinates(this)
-        //setupLocation()
 
         val bundle = intent.extras
         if (bundle != null) {

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/HelpPageActivity.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/HelpPageActivity.kt
@@ -1,7 +1,7 @@
 package com.github.h3lp3rs.h3lp
 
+import LocationHelper
 import android.content.Intent
-import android.location.Location
 import android.os.Bundle
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
@@ -10,7 +10,6 @@ import com.github.h3lp3rs.h3lp.database.Databases.Companion.databaseOf
 import com.github.h3lp3rs.h3lp.databinding.ActivityHelpPageBinding
 import com.github.h3lp3rs.h3lp.dataclasses.EmergencyInformation
 import com.github.h3lp3rs.h3lp.dataclasses.Helper
-import com.github.h3lp3rs.h3lp.locationmanager.GeneralLocationManager
 import com.github.h3lp3rs.h3lp.messaging.ChatActivity
 import com.github.h3lp3rs.h3lp.messaging.Conversation
 import com.github.h3lp3rs.h3lp.messaging.Conversation.Companion.UNIQUE_CONVERSATION_ID
@@ -40,6 +39,7 @@ class HelpPageActivity : AppCompatActivity(), CoroutineScope by MainScope() {
     private var destinationLong = 6.667
     private var currentLong: Double = 0.0
     private var currentLat: Double = 0.0
+    private val locationHelper = LocationHelper()
 
     // TODO : again, this is hardcoded for testing purposes but it will be removed (and initialized
     //  to null after the linking of activities)
@@ -81,7 +81,10 @@ class HelpPageActivity : AppCompatActivity(), CoroutineScope by MainScope() {
         apiHelper = GoogleAPIHelper(resources.getString(R.string.google_maps_key))
 
         // Initialize the current user's location
-        setupLocation()
+        locationHelper.requireAndHandleCoordinates(this) {
+            currentLat = it.latitude
+            currentLong = it.longitude
+        }
 
         // Displays the path to the user in need on the map fragment and, when the path has been
         // retrieved (through a google directions API request), computes and displays the time to
@@ -97,23 +100,6 @@ class HelpPageActivity : AppCompatActivity(), CoroutineScope by MainScope() {
         button_reject.setOnClickListener { goToMainPage() }
 
         setUpEmergencyCancellation()
-    }
-
-    /**
-     * Initializes the user's current location or returns to the main page in case a mistake occurred
-     * during the location information retrieval
-     */
-    private fun setupLocation() {
-        val futureLocation = GeneralLocationManager.get().getCurrentLocation(this)
-        futureLocation.handle { location, exception ->
-            if (exception != null) {
-                // In case the permission to access the location is missing
-                goToActivity(MainPageActivity::class.java)
-            } else {
-                currentLat = location.latitude
-                currentLong = location.longitude
-            }
-        }
     }
 
     /**

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/HelpParametersActivity.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/HelpParametersActivity.kt
@@ -1,9 +1,8 @@
 package com.github.h3lp3rs.h3lp
 
 
+import LocationHelper
 import android.content.Intent
-import android.location.Location
-import android.location.LocationManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -23,7 +22,6 @@ import com.github.h3lp3rs.h3lp.dataclasses.MedicalInformation
 import com.github.h3lp3rs.h3lp.storage.Storages.*
 import com.github.h3lp3rs.h3lp.storage.Storages.Companion.storageOf
 import com.github.h3lp3rs.h3lp.database.Databases.CONVERSATION_IDS
-import com.github.h3lp3rs.h3lp.locationmanager.GeneralLocationManager
 import com.github.h3lp3rs.h3lp.messaging.Conversation
 import com.github.h3lp3rs.h3lp.storage.Storages
 import java.util.*
@@ -41,13 +39,12 @@ const val EXTRA_HELPEE_ID = "helpee_id"
 class HelpParametersActivity : AppCompatActivity() {
     // userLocation contains the user's current coordinates (is initialized to null since we could
     // encounter an error while getting the user's location)
-    private var userLocation: Location? = null
-    private var latitude: Double? = null
-    private var longitude: Double? = null
+
     private var meds: ArrayList<String> = ArrayList()
     private var skills: HelperSkills? = null
     private val currentTime: Date = Calendar.getInstance().time
     private var calledEmergencies = false
+    private var locationHelper = LocationHelper()
     //TODO this is only for testing, it will be put back to null after implementing the
     // communication of emergencies
     private var helpeeId : String? = "test_end_to_end"
@@ -58,17 +55,19 @@ class HelpParametersActivity : AppCompatActivity() {
 
         // Get the coordinates and display them on the screen to enable the user to give their exact
         // location to the emergency services
-        updateCoordinates()
+        locationHelper.updateCoordinates(this)
+
         val locationInformation: TextView = findViewById(R.id.location_information)
         val coordinatesText = getString(R.string.current_location)
-        if (userLocation != null) {
-            latitude = userLocation!!.latitude
-            longitude = userLocation!!.longitude
+
+        val latitude = locationHelper.getUserLatitude()
+        val longitude = locationHelper.getUserLongitude()
+        if (latitude != null && longitude != null) {
             locationInformation.text = String.format(
                 "%s latitude: %.4f longitude: %.4f",
                 coordinatesText,
-                userLocation!!.latitude,
-                userLocation!!.longitude
+                latitude,
+                longitude
             )
         } else {
             // If the user didn't allow location permissions, they won't be able to see their
@@ -127,11 +126,11 @@ class HelpParametersActivity : AppCompatActivity() {
      */
     private fun launchEmergencyCall() {
         calledEmergencies = true
-        updateCoordinates()
+        locationHelper.updateCoordinates(this)
         val emergencyNumber =
             LocalEmergencyCaller.getLocalEmergencyNumber(
-                userLocation?.longitude,
-                userLocation?.latitude,
+                locationHelper.getUserLongitude(),
+                locationHelper.getUserLatitude(),
                 this
             )
 
@@ -194,7 +193,7 @@ class HelpParametersActivity : AppCompatActivity() {
             newEmergenciesDb.clearAllListeners()
             // Create and send the emergency object
             val id = it + 1
-            val emergencyInfo = EmergencyInformation(id.toString(), latitude!!, longitude!!, skills!!, meds, currentTime, medicalInfo, ArrayList())
+            val emergencyInfo = EmergencyInformation(id.toString(), locationHelper.getUserLatitude()!!, locationHelper.getUserLongitude()!!, skills!!, meds, currentTime, medicalInfo, ArrayList())
             EmergencyInfoRepository(emergenciesDb).insert(emergencyInfo)
             // Raise the appropriate flags to notify potential helpers
             val needed = skills!!
@@ -263,17 +262,5 @@ class HelpParametersActivity : AppCompatActivity() {
             }
         }
         return Pair(meds, skills)
-    }
-
-    /**
-     * Function that updates the user's current coordinates
-     */
-    private fun updateCoordinates() {
-        val futureLocation = GeneralLocationManager.get().getCurrentLocation(this)
-        futureLocation.thenAccept {
-            userLocation = Location(LocationManager.GPS_PROVIDER)
-            userLocation?.longitude = it.longitude
-            userLocation?.latitude = it.latitude
-        }
     }
 }

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/MapsFragment.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/MapsFragment.kt
@@ -2,14 +2,12 @@ package com.github.h3lp3rs.h3lp
 
 import LocationHelper
 import android.annotation.SuppressLint
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
-import com.github.h3lp3rs.h3lp.locationmanager.GeneralLocationManager
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
@@ -76,7 +74,7 @@ class MapsFragment : Fragment(), CoroutineScope by MainScope(), GoogleMap.OnPoly
                 )
             )
 
-            // execute pending functions
+            // Execute pending functions
             for (f in onMapReadyQueue){
                 f()
             }
@@ -237,10 +235,8 @@ class MapsFragment : Fragment(), CoroutineScope by MainScope(), GoogleMap.OnPoly
      * Utility function to remove all markers corresponding to one utility
      */
     fun removeMarkers(utility: String) {
-        if(placedMarkers.containsKey(utility)){
-            for (marker in placedMarkers[utility]!!) {
-                marker.remove()
-            }
+        placedMarkers[utility]?.let { markersList ->
+            markersList.map {it.remove()}
         }
 
         placedMarkers[utility] = arrayListOf()

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/NearbyUtilitiesActivity.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/NearbyUtilitiesActivity.kt
@@ -67,6 +67,8 @@ class NearbyUtilitiesActivity : AppCompatActivity(), CoroutineScope by MainScope
         }
 
         setupSelectionButtons()
+
+        // Wait for the map to search and show the utilities asked by the user
         mapsFragment.executeOnMapReady(this::setRequestedButton)
     }
 

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/locationmanager/LocationHelper.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/locationmanager/LocationHelper.kt
@@ -1,0 +1,53 @@
+import android.content.Context
+import android.content.Intent
+import android.location.Location
+import android.location.LocationManager
+import com.github.h3lp3rs.h3lp.MainPageActivity
+import com.github.h3lp3rs.h3lp.locationmanager.GeneralLocationManager
+
+
+/**
+ * SuperActivity that is common to all activities using localization
+ */
+class LocationHelper {
+    private var userLocation: Location? = null
+
+    fun getUserLatitude(): Double?{
+        return userLocation?.latitude
+    }
+
+    fun getUserLongitude(): Double?{
+        return userLocation?.longitude
+    }
+
+    /**
+     * Function that updates the user's current coordinates
+     * @param context: the context of the activity using the coordinates
+     */
+    fun updateCoordinates(context: Context) {
+        val futureLocation = GeneralLocationManager.get().getCurrentLocation(context)
+        futureLocation.thenAccept {
+            userLocation = Location(LocationManager.GPS_PROVIDER)
+            userLocation?.longitude = it.longitude
+            userLocation?.latitude = it.latitude
+        }
+    }
+
+    /**
+     * Updates handles the user's current coordinates as wanted, or returns to the
+     * main activity in case of errors.
+     * @param : context:
+     */
+    fun requireAndHandleCoordinates(context: Context, onSuccess: (location: Location) -> Unit) {
+        val futureLocation = GeneralLocationManager.get().getCurrentLocation(context)
+        futureLocation.handle { location, exception ->
+            if (exception != null) {
+                // In case the permission to access the location is missing
+                val intent = Intent(context, MainPageActivity::class.java)
+                context.startActivity(intent)
+            } else {
+                onSuccess(location)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/locationmanager/LocationHelper.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/locationmanager/LocationHelper.kt
@@ -46,6 +46,7 @@ class LocationHelper {
                 val intent = Intent(context, MainPageActivity::class.java)
                 context.startActivity(intent)
             } else {
+                userLocation = location
                 onSuccess(location)
             }
         }

--- a/app/src/main/java/com/github/h3lp3rs/h3lp/locationmanager/LocationHelper.kt
+++ b/app/src/main/java/com/github/h3lp3rs/h3lp/locationmanager/LocationHelper.kt
@@ -22,7 +22,7 @@ class LocationHelper {
 
     /**
      * Function that updates the user's current coordinates
-     * @param context: the context of the activity using the coordinates
+     * @param context The context of the activity using the coordinates
      */
     fun updateCoordinates(context: Context) {
         val futureLocation = GeneralLocationManager.get().getCurrentLocation(context)
@@ -35,8 +35,9 @@ class LocationHelper {
 
     /**
      * Updates handles the user's current coordinates as wanted, or returns to the
-     * main activity in case of errors.
-     * @param : context:
+     * main activity in case of errors
+     * @param context The context of the activity calling using the location
+     * @param onSuccess The callback to execute once the location is available
      */
     fun requireAndHandleCoordinates(context: Context, onSuccess: (location: Location) -> Unit) {
         val futureLocation = GeneralLocationManager.get().getCurrentLocation(context)


### PR DESCRIPTION
Addresses #203 and defines an auxiliary class to group all location related code in a single place. I chose to define an auxiliary class instead of a superclass as planned so that it can be used in both Fragments and Activities.

 The hierarchy should now be clearer, everything related to the APIs is in GoogleAPIHelper, the user's localization is dealt with by the LocationHelper, and all the actions on the map are done by the MapsFragment. The activities themselves are now purged of all map-specific code.

On another side, I also added a class to help modularise tests and test constants that may be used in multiple classes by adding a super class that can be inherited by all the tests. I took the opportunity to make a pass on all the tests and cleanup a little bit.

Reviewing all that might be hard considering all the small changes to all the tests files, you might want to review the first commit seperately to understand the location-related changes first.